### PR TITLE
Fixed config group attachment error

### DIFF
--- a/cisco_sdwan/base/models_vmanage.py
+++ b/cisco_sdwan/base/models_vmanage.py
@@ -662,7 +662,7 @@ class ConfigGroupValues(Config2Item):
     def put_raise(self, api: Rest, **path_vars: str) -> Sequence[str]:
         result = api.put(self.put_data(), ConfigGroupValues.api_path.resolve(**path_vars).put)
 
-        return [entry.get('device-id') for entry in result]
+        return result
 
 
 class AssociatedDeviceModel(ConfigRequestModel):


### PR DESCRIPTION
When restoring configuration groups, it fails with

`INFO: Config-group edge_basic, associate: C8K-172343D2-7380-8B1B-5509-6FCB24AFA689, C8K-15411CCC-D476-0B3B-21F2-5D6AC387EE7B
Traceback (most recent call last):
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/__main__.py", line 151, in main
    task_output = task.runner(parsed_task_args, api)
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/tasks/implementation/_restore.py", line 156, in runner
    getattr(TaskRestore, attach_step_fn)(self, api, parsed_args.workdir)
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/tasks/implementation/_restore.py", line 294, in restore_deployments
    deploy_data = self.cfg_group_deploy_data(
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/tasks/common.py", line 581, in cfg_group_deploy_data
    affected_uuids = restore_values(group_name, saved_id, target_id)
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/tasks/common.py", line 555, in restore_values
    diff_uuids = diff_values.put_raise(api, configGroupId=config_grp_target_id)
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/base/models_vmanage.py", line 665, in put_raise
    return [entry.get('device-id', entry) for entry in result]
  File "/Users/tzarski/Downloads/sastre-master/cisco_sdwan/base/models_vmanage.py", line 665, in <listcomp>
    return [entry.get('device-id', entry) for entry in result]
AttributeError: 'str' object has no attribute 'get'`

This is because results is already list of string uuids so no reason to parse it. With that fix config group attachment works OK in 20.12.