### PR TITLE
Bump up pydantic version to v2

### DIFF
--- a/cisco_sdwan/base/models_base.py
+++ b/cisco_sdwan/base/models_base.py
@@ -14,7 +14,7 @@ from typing import Sequence, Tuple, Union, Iterator, Callable, Mapping, Any, Opt
 from operator import attrgetter
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
-from pydantic.v1 import  BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 from requests.exceptions import Timeout
 from .rest_api import RestAPIException, Rest
 

--- a/cisco_sdwan/base/models_base.py
+++ b/cisco_sdwan/base/models_base.py
@@ -14,7 +14,7 @@ from typing import Sequence, Tuple, Union, Iterator, Callable, Mapping, Any, Opt
 from operator import attrgetter
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
-from pydantic import BaseModel, Extra
+from pydantic.v1 import  BaseModel, Extra
 from requests.exceptions import Timeout
 from .rest_api import RestAPIException, Rest
 

--- a/cisco_sdwan/base/models_vmanage.py
+++ b/cisco_sdwan/base/models_vmanage.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from collections import namedtuple
 from copy import deepcopy
 from urllib.parse import quote_plus
-from pydantic import Field
+from pydantic.v1 import  Field
 from .rest_api import Rest, RestAPIException
 from .catalog import register, op_register
 from .models_base import (ApiItem, IndexApiItem, ConfigItem, Config2Item, IndexConfigItem, RecordItem, RealtimeItem,

--- a/cisco_sdwan/base/models_vmanage.py
+++ b/cisco_sdwan/base/models_vmanage.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from collections import namedtuple
 from copy import deepcopy
 from urllib.parse import quote_plus
-from pydantic.v1 import  Field
+from pydantic.v1 import Field
 from .rest_api import Rest, RestAPIException
 from .catalog import register, op_register
 from .models_base import (ApiItem, IndexApiItem, ConfigItem, Config2Item, IndexConfigItem, RecordItem, RealtimeItem,

--- a/cisco_sdwan/tasks/common.py
+++ b/cisco_sdwan/tasks/common.py
@@ -14,7 +14,7 @@ from shutil import rmtree
 from collections import namedtuple
 from typing import List, Tuple, Iterator, Union, Optional, Any, Iterable, Type, TypeVar, Sequence, Mapping
 from zipfile import ZipFile, ZIP_DEFLATED
-from pydantic import ValidationError
+from pydantic.v1 import  ValidationError
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.models_base import DATA_DIR
 from cisco_sdwan.base.models_vmanage import (DeviceTemplate, DeviceTemplateValues, DeviceTemplateAttached,

--- a/cisco_sdwan/tasks/common.py
+++ b/cisco_sdwan/tasks/common.py
@@ -14,7 +14,7 @@ from shutil import rmtree
 from collections import namedtuple
 from typing import List, Tuple, Iterator, Union, Optional, Any, Iterable, Type, TypeVar, Sequence, Mapping
 from zipfile import ZipFile, ZIP_DEFLATED
-from pydantic.v1 import  ValidationError
+from pydantic.v1 import ValidationError
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.models_base import DATA_DIR
 from cisco_sdwan.base.models_vmanage import (DeviceTemplate, DeviceTemplateValues, DeviceTemplateAttached,

--- a/cisco_sdwan/tasks/implementation/_attach_detach.py
+++ b/cisco_sdwan/tasks/implementation/_attach_detach.py
@@ -1,7 +1,7 @@
 import argparse
 from functools import partial
 from typing import Union, Optional, Callable, Tuple, Set, Mapping, Iterable
-from pydantic.v1 import  validator, conint
+from pydantic.v1 import validator, conint
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.catalog import is_index_supported

--- a/cisco_sdwan/tasks/implementation/_attach_detach.py
+++ b/cisco_sdwan/tasks/implementation/_attach_detach.py
@@ -1,7 +1,7 @@
 import argparse
 from functools import partial
 from typing import Union, Optional, Callable, Tuple, Set, Mapping, Iterable
-from pydantic import validator, conint
+from pydantic.v1 import  validator, conint
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.catalog import is_index_supported

--- a/cisco_sdwan/tasks/implementation/_backup.py
+++ b/cisco_sdwan/tasks/implementation/_backup.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, List, Dict, Any
-from pydantic.v1 import  validator, root_validator
+from pydantic.v1 import validator, root_validator
 from uuid import uuid4
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException

--- a/cisco_sdwan/tasks/implementation/_backup.py
+++ b/cisco_sdwan/tasks/implementation/_backup.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, List, Dict, Any
-from pydantic import validator, root_validator
+from pydantic.v1 import  validator, root_validator
 from uuid import uuid4
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException

--- a/cisco_sdwan/tasks/implementation/_certificate.py
+++ b/cisco_sdwan/tasks/implementation/_certificate.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Callable, Dict, Any
-from pydantic import validator, root_validator
+from pydantic.v1 import  validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.models_vmanage import EdgeCertificate, EdgeCertificateSync

--- a/cisco_sdwan/tasks/implementation/_certificate.py
+++ b/cisco_sdwan/tasks/implementation/_certificate.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Callable, Dict, Any
-from pydantic.v1 import  validator, root_validator
+from pydantic.v1 import validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.models_vmanage import EdgeCertificate, EdgeCertificateSync

--- a/cisco_sdwan/tasks/implementation/_delete.py
+++ b/cisco_sdwan/tasks/implementation/_delete.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Dict, Any
-from pydantic.v1 import  validator, root_validator
+from pydantic.v1 import validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL, ordered_tags, is_index_supported

--- a/cisco_sdwan/tasks/implementation/_delete.py
+++ b/cisco_sdwan/tasks/implementation/_delete.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Dict, Any
-from pydantic import validator, root_validator
+from pydantic.v1 import  validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL, ordered_tags, is_index_supported

--- a/cisco_sdwan/tasks/implementation/_list.py
+++ b/cisco_sdwan/tasks/implementation/_list.py
@@ -1,7 +1,7 @@
 import argparse
 from typing import Union, Optional, List, Callable, Dict, Any
 from operator import itemgetter
-from pydantic.v1 import  validator, root_validator
+from pydantic.v1 import validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL

--- a/cisco_sdwan/tasks/implementation/_list.py
+++ b/cisco_sdwan/tasks/implementation/_list.py
@@ -1,7 +1,7 @@
 import argparse
 from typing import Union, Optional, List, Callable, Dict, Any
 from operator import itemgetter
-from pydantic import validator, root_validator
+from pydantic.v1 import  validator, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL

--- a/cisco_sdwan/tasks/implementation/_migrate.py
+++ b/cisco_sdwan/tasks/implementation/_migrate.py
@@ -2,7 +2,7 @@ import argparse
 from typing import Union, Optional
 from uuid import uuid4
 from contextlib import suppress
-from pydantic import validator
+from pydantic.v1 import  validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL, ordered_tags

--- a/cisco_sdwan/tasks/implementation/_migrate.py
+++ b/cisco_sdwan/tasks/implementation/_migrate.py
@@ -2,7 +2,7 @@ import argparse
 from typing import Union, Optional
 from uuid import uuid4
 from contextlib import suppress
-from pydantic.v1 import  validator
+from pydantic.v1 import validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import catalog_iter, CATALOG_TAG_ALL, ordered_tags

--- a/cisco_sdwan/tasks/implementation/_report.py
+++ b/cisco_sdwan/tasks/implementation/_report.py
@@ -5,7 +5,7 @@ import yaml
 from datetime import date
 from difflib import unified_diff, HtmlDiff
 from typing import Union, Optional, Iterator, List, Dict, Any, NamedTuple, Type, Tuple, Callable, Set
-from pydantic import BaseModel, ValidationError, validator, Extra, root_validator
+from pydantic.v1 import  BaseModel, ValidationError, validator, Extra, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import CATALOG_TAG_ALL, ordered_tags

--- a/cisco_sdwan/tasks/implementation/_report.py
+++ b/cisco_sdwan/tasks/implementation/_report.py
@@ -5,7 +5,7 @@ import yaml
 from datetime import date
 from difflib import unified_diff, HtmlDiff
 from typing import Union, Optional, Iterator, List, Dict, Any, NamedTuple, Type, Tuple, Callable, Set
-from pydantic.v1 import  BaseModel, ValidationError, validator, Extra, root_validator
+from pydantic.v1 import BaseModel, ValidationError, validator, Extra, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import CATALOG_TAG_ALL, ordered_tags

--- a/cisco_sdwan/tasks/implementation/_restore.py
+++ b/cisco_sdwan/tasks/implementation/_restore.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Sequence, Dict, Set, Any
-from pydantic import validator, root_validator
+from pydantic.v1 import  validator, root_validator
 from uuid import uuid4
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException, is_version_newer, response_id

--- a/cisco_sdwan/tasks/implementation/_restore.py
+++ b/cisco_sdwan/tasks/implementation/_restore.py
@@ -1,6 +1,6 @@
 import argparse
 from typing import Union, Optional, Sequence, Dict, Set, Any
-from pydantic.v1 import  validator, root_validator
+from pydantic.v1 import validator, root_validator
 from uuid import uuid4
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest, RestAPIException, is_version_newer, response_id

--- a/cisco_sdwan/tasks/implementation/_show.py
+++ b/cisco_sdwan/tasks/implementation/_show.py
@@ -5,7 +5,7 @@ from functools import partial
 from concurrent import futures
 from datetime import datetime, timedelta, timezone
 from operator import attrgetter
-from pydantic import validator, conint, root_validator
+from pydantic.v1 import  validator, conint, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import CATALOG_TAG_ALL, op_catalog_iter, OpType

--- a/cisco_sdwan/tasks/implementation/_show.py
+++ b/cisco_sdwan/tasks/implementation/_show.py
@@ -5,7 +5,7 @@ from functools import partial
 from concurrent import futures
 from datetime import datetime, timedelta, timezone
 from operator import attrgetter
-from pydantic.v1 import  validator, conint, root_validator
+from pydantic.v1 import validator, conint, root_validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.base.catalog import CATALOG_TAG_ALL, op_catalog_iter, OpType

--- a/cisco_sdwan/tasks/implementation/_show_template.py
+++ b/cisco_sdwan/tasks/implementation/_show_template.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from collections import namedtuple
 from typing import List, Union, Optional, Callable
 from operator import itemgetter, attrgetter
-from pydantic.v1 import  validator
+from pydantic.v1 import validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import RestAPIException, Rest
 from cisco_sdwan.base.catalog import catalog_iter

--- a/cisco_sdwan/tasks/implementation/_show_template.py
+++ b/cisco_sdwan/tasks/implementation/_show_template.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from collections import namedtuple
 from typing import List, Union, Optional, Callable
 from operator import itemgetter, attrgetter
-from pydantic import validator
+from pydantic.v1 import  validator
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import RestAPIException, Rest
 from cisco_sdwan.base.catalog import catalog_iter

--- a/cisco_sdwan/tasks/implementation/_transform.py
+++ b/cisco_sdwan/tasks/implementation/_transform.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from copy import deepcopy
 from contextlib import suppress
 from typing import Union, Optional, Tuple, List, Dict, Type, Callable, Any
-from pydantic.v1 import  BaseModel, validator, ValidationError, Extra, root_validator
+from pydantic.v1 import BaseModel, validator, ValidationError, Extra, root_validator
 import yaml
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest

--- a/cisco_sdwan/tasks/implementation/_transform.py
+++ b/cisco_sdwan/tasks/implementation/_transform.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 from copy import deepcopy
 from contextlib import suppress
 from typing import Union, Optional, Tuple, List, Dict, Type, Callable, Any
-from pydantic import BaseModel, validator, ValidationError, Extra, root_validator
+from pydantic.v1 import  BaseModel, validator, ValidationError, Extra, root_validator
 import yaml
 from cisco_sdwan.__version__ import __doc__ as title
 from cisco_sdwan.base.rest_api import Rest

--- a/cisco_sdwan/tasks/models.py
+++ b/cisco_sdwan/tasks/models.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, Any, Dict
-from pydantic import BaseModel, validator, Field, Extra
+from pydantic.v1 import  BaseModel, validator, Field, Extra
 from cisco_sdwan.base.catalog import OpType, CATALOG_TAG_ALL, op_catalog_tags, op_catalog_commands, catalog_tags
 from cisco_sdwan.tasks.utils import OpCmdOptions
 from cisco_sdwan.tasks.validators import validate_regex, validate_filename, validate_workdir

--- a/cisco_sdwan/tasks/models.py
+++ b/cisco_sdwan/tasks/models.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, Any, Dict
-from pydantic.v1 import  BaseModel, validator, Field, Extra
+from pydantic.v1 import BaseModel, validator, Field, Extra
 from cisco_sdwan.base.catalog import OpType, CATALOG_TAG_ALL, op_catalog_tags, op_catalog_commands, catalog_tags
 from cisco_sdwan.tasks.utils import OpCmdOptions
 from cisco_sdwan.tasks.validators import validate_regex, validate_filename, validate_workdir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.8"
 dependencies = [
     "requests",
     "PyYAML",
-    "pydantic>=1.10, <2.0"
+    "pydantic==2.5"
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic>=1.10, <2.0
+pydantic==2.5
 PyYAML==6.0.1
 requests==2.31.0
 urllib3==2.1.0


### PR DESCRIPTION
Changed pydantic version to 2.5. Replaced imports to support backward compatibility to use pydantic <2. (import pydantic.v1).