### PR TITLE
Deleted unnecessary code from models.py

### DIFF
--- a/cisco_sdwan/tasks/models.py
+++ b/cisco_sdwan/tasks/models.py
@@ -46,7 +46,7 @@ def validate_workdir_conditional(workdir: str, info: ValidationInfo) -> str:
     return workdir
 
 
-def const(field_type: type[Any], default_value: Any) -> Annotated[type[Any], ...]:
+def const(field_type: Any, default_value: Any) -> Annotated[Any, ...]:
     """
     Defines a model field as constant. That is, it cannot be set to any value other than the default value.
     """


### PR DESCRIPTION
Currently version 1.23 cannot perform any task due to the problem with typing issue:
```
sdwan --verbose -a 192.168.1.1 -u username -p password --port 9999 backup all --workdir /sastre_backups/2024-03-21 --no-rollover
Traceback (most recent call last):
  File "/nobackup/bradwan/regression/bin/sdwan", line 5, in <module>
    from cisco_sdwan.__main__ import main
  File "/nobackup/bradwan/regression/lib/python3.8/site-packages/cisco_sdwan/__main__.py", line 22, in <module>
    from .tasks.implementation import *
  File "/nobackup/bradwan/regression/lib/python3.8/site-packages/cisco_sdwan/tasks/implementation/__init__.py", line 7, in <module>
    from ._backup import TaskBackup, BackupArgs
  File "/nobackup/bradwan/regression/lib/python3.8/site-packages/cisco_sdwan/tasks/implementation/_backup.py", line 14, in <module>
    from cisco_sdwan.tasks.models import TaskArgs, CatalogTag
  File "/nobackup/bradwan/regression/lib/python3.8/site-packages/cisco_sdwan/tasks/models.py", line 48, in <module>
    def const(field_type: type[Any], default_value: Any) -> Annotated[type[Any], ...]:
TypeError: 'type' object is not subscriptable
```