### PR TITLE
Fixed the potentail certificate verification failed during logout api called

### DIFF
--- a/cisco_sdwan/base/rest_api.py
+++ b/cisco_sdwan/base/rest_api.py
@@ -121,7 +121,7 @@ class Rest:
         return True
 
     def logout(self) -> bool:
-        response = self.session.get(f'{self.base_url}/logout', params={'nocache': str(int(time()))})
+        response = self.session.get(f'{self.base_url}/logout', params={'nocache': str(int(time()))}, verify=self.verify)
         return response.status_code == requests.codes.ok
 
     @property


### PR DESCRIPTION
This PR has fixed the potential certificate verification error that could occur during the logout API call. 

Initially, I considered adding `verify=False` in the logout API call. However, I realized that the Rest class already has a `self.verify` attribute. Although it's not configurable at the moment, I believe that following the convention is a good idea.

<img width="1179" alt="image" src="https://github.com/CiscoDevNet/sastre/assets/1746507/17fcc6bd-d6b3-4364-b73d-00c2f929cb50">
