### PR TITLE
Fixed the potentail certificate verification failed during logout api called

### DIFF
--- a/cisco_sdwan/base/rest_api.py
+++ b/cisco_sdwan/base/rest_api.py
@@ -120,10 +120,10 @@ class Rest:
 
     def logout(self) -> bool:
         if is_version_newer('20.11', self.server_version):
-            response = self.session.post(f'{self.base_url}/logout', allow_redirects=False)
+            response = self.session.post(f'{self.base_url}/logout', allow_redirects=False, verify=self.verify)
         else:
             response = self.session.get(f'{self.base_url}/logout', params={'nocache': str(int(time()))},
-                                        allow_redirects=False)
+                                        allow_redirects=False, verify=self.verify)
 
         return response.status_code == requests.codes.ok
 


### PR DESCRIPTION
This PR has fixed the potential certificate verification error that could occur during the logout API call.

Initially, I considered adding verify=False in the logout API call. However, I realized that the Rest class already has a self.verify attribute. Although it's not configurable at the moment, I believe that following the convention is a good idea.

![image](https://github.com/CiscoDevNet/sastre/assets/1746507/acba5f0e-c1dd-4426-bd69-3c3f48752e8c)
