### PR TITLE
Logout API will return 302 Found, not 200 ok

### DIFF
--- a/cisco_sdwan/base/rest_api.py
+++ b/cisco_sdwan/base/rest_api.py
@@ -125,7 +125,7 @@ class Rest:
             response = self.session.get(f'{self.base_url}/logout', params={'nocache': str(int(time()))},
                                         allow_redirects=False)
 
-        return response.status_code == requests.codes.ok
+        return response.status_code == requests.codes.found
 
     @property
     def server_version(self) -> str:


### PR DESCRIPTION
I tested Sastre in SD-WAN versions 20.13 and 20.11. Whether the logout API is a GET or POST request, it returns a 302 Found status code and redirects to the welcome page. 

<img width="1268" alt="image" src="https://github.com/CiscoDevNet/sastre/assets/1746507/c8b5ac52-3c4a-4a27-b730-79c5dc29eb20">


Currently, there are no method calls to verify the success of the logout, but I suggest that we modify the last line in the function to return the correct value when the logout is successful.