### PR TITLE
Add support for 'bfd summary' in 'sdwan show realtime'

### DIFF
--- a/cisco_sdwan/base/models_vmanage.py
+++ b/cisco_sdwan/base/models_vmanage.py
@@ -2438,6 +2438,11 @@ class BfdSessions(RealtimeItem):
     fields_std = ('system_ip', 'site_id', 'local_color', 'color', 'state')
     fields_ext = ('src_ip', 'src_port', 'dst_ip', 'dst_port')
 
+@op_register('bfd', 'summary', 'BFD summary')
+class BfdSummary(RealtimeItem):
+    api_path = ApiPath('device/bfd/summary', None, None, None)
+    fields_std = ('vdevice_name', 'vdevice_host_name',  'bfd_sessions_total', 'bfd_sessions_up', 'bfd_sessions_max', 'bfd_sessions_flap')
+    fields_ext = ('poll_interval', 'lastupdated')
 
 @op_register('control', 'connections', 'Control connections')
 class DeviceControlConnections(RealtimeItem):


### PR DESCRIPTION
Brief:
The sdwan show realtime command in Sastre currently supports the bfd sessions sub-command for retrieving real-time BFD session information from vManage. Cisco SD-WAN also provides a bfd summary API endpoint that returns summary statistics about BFD sessions per device.

Changes:
This pull request adds support for a new sub-command:
```
sdwan show realtime --device-type cedge bfd summary
```
by introducing a BfdSummary class in models_vmanage.py that queries the device/bfd/summary vManage API endpoint.

Usage Examples:
```
sdwan show realtime --device-type cedge bfd summary
```

```
$ sdwan show realtime --device-type cedge bfd summary
vManage address: 10.100.100.172
vManage user: sdwan
vManage password:
*** BFD summary ***
+=====================================================================================================================================================================================================================================+
| Device | Vdevice-Name | Vdevice-Host-Name | device.bfd.deviceDataBfdSummary.sessionsTotal | device.bfd.deviceDataBfdSummary.sessionsUp | device.bfd.deviceDataBfdSummary.sessionsMax | device.bfd.deviceDataBfdSummary.sessionsFlap |
+=====================================================================================================================================================================================================================================+
| Edge1  | 10.0.0.1     | Edge1             | 2                                             | 2                                          | 2                                           | 0                                            |
+--------+--------------+-------------------+-----------------------------------------------+--------------------------------------------+---------------------------------------------+----------------------------------------------+
| Edge2  | 10.0.0.2     | Edge2             | 2                                             | 2                                          | 2                                           | 1                                            |
+--------+--------------+-------------------+-----------------------------------------------+--------------------------------------------+---------------------------------------------+----------------------------------------------+
```

```
sdwan show realtime --device-type cedge bfd summary --detail
vManage address: 10.100.100.172
vManage user: sdwan
vManage password:
*** BFD summary ***
+====================================================================================================================================================================================================================================================================================================================================+
| Device | Vdevice-Name | Vdevice-Host-Name | device.bfd.deviceDataBfdSummary.sessionsTotal | device.bfd.deviceDataBfdSummary.sessionsUp | device.bfd.deviceDataBfdSummary.sessionsMax | device.bfd.deviceDataBfdSummary.sessionsFlap | device.bfd.deviceDataBfdSummary.appRoutePollIn | device.bfd.deviceDataBfdSummary.lastUpdated |
+====================================================================================================================================================================================================================================================================================================================================+
| Edge1  | 10.0.0.1     | Edge1             | 2                                             | 2                                          | 2                                           | 0                                            | 600000                                         | 1766720949508                               |
+--------+--------------+-------------------+-----------------------------------------------+--------------------------------------------+---------------------------------------------+----------------------------------------------+------------------------------------------------+---------------------------------------------+
| Edge2  | 10.0.0.2     | Edge2             | 2                                             | 2                                          | 2                                           | 1                                            | 600000                                         | 1766720949513                               |
+--------+--------------+-------------------+-----------------------------------------------+--------------------------------------------+---------------------------------------------+----------------------------------------------+------------------------------------------------+---------------------------------------------+
```

Testing Performed:

Validated locally with Python editable install:
```
pip install --editable .
```

Verified API call to /dataservice/device/bfd/summary returns expected JSON structure from vManage 20.18.1 and cEdge 17.18.01a
Confirmed CLI output in both standard and extended view modes.
Checked behavior with multiple cEdge devices.

